### PR TITLE
GTVscode: Add user friendly display name and gallery banner

### DIFF
--- a/packages/git-temporal-vscode/package.json
+++ b/packages/git-temporal-vscode/package.json
@@ -1,9 +1,14 @@
 {
-  "name": "Git Temporal",
+  "name": "git-temporal-vscode",
+  "displayName": "Git Temporal",
   "description": "Git Temporal - all about time and time travel",
   "icon": "images/gticon.png",
   "version": "0.4.0",
   "publisher": "bee",
+  "galleryBanner": {
+    "color": "#1b2b34",
+    "theme": "dark"
+  },
   "engines": {
     "vscode": "^1.25.0"
   },


### PR DESCRIPTION
GT was hard to find in VSCode marketplace because it was using the name from package.json which needs to be in dasherized format.  

Adds `displayName` and  dark themed `galleryBanner` to match out icon. 