### PR TITLE
fix regression with vscode extension 

### DIFF
--- a/packages/git-temporal-react/index.vscode.js
+++ b/packages/git-temporal-react/index.vscode.js
@@ -1,13 +1,14 @@
 /* eslint-disable */
 var react = require('react');
 var reactDom = require('react-dom');
-var GTR = require('app/Index');
 
 const element = document.getElementById('gitTemporal');
 const currentPath = element.getAttribute('data-current-path');
 
 window.IS_VSCODE_WEBVIEW = 1;
 window.GTDEBUG = 1;
+
+var GTR = require('app/Index');
 
 console.log(
   `Attempting to render,

--- a/packages/git-temporal-vscode/package.json
+++ b/packages/git-temporal-vscode/package.json
@@ -10,7 +10,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "1.25.0"
+    "vscode": "^1.25.0"
   },
   "repository": "https://github.com/git-temporal/git-temporal",
   "keywords": [


### PR DESCRIPTION
Whilst flailing with CI build earlier, I wrongly changed the location where GTR is loaded.  It absolutely needs to come after window.IS_VSCODE_WEBVIEW = 1; or GTR doesn't know it's embedded in vscode.

Also discovered that engines.version is now exact?  According to their docs, https://code.visualstudio.com/api/references/extension-manifest#fields, "^1.25.0" means >= 1.25.0 